### PR TITLE
fix: animation

### DIFF
--- a/src/styles/animations.ts
+++ b/src/styles/animations.ts
@@ -1,13 +1,13 @@
 import { css, keyframes } from 'styled-components';
 
 export const Up100 = keyframes`
-  0% {bottom: -100%; }
-  100% {bottom: 0; }
+  0% {transform: translateY(100%); }
+  100% {transform: translateY(0); }
 `;
 
 export const Down100 = keyframes`
-  0% {bottom: 0%; }
-  100% {bottom: -100%; }
+  0% {transform: translateY(0%); }
+  100% {transform: translateY(100%); }
 `;
 
 export const BeSmaller = css`


### PR DESCRIPTION
bottom으로 계산하면 레이아웃이 계속 계산돼서 속도가 느림
그래서 transform으로 변경