### PR TITLE
fix: 내역 추가 모달창에서 날짜 및 monthselector 오류

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,10 @@ import useGetCurrentDate from 'hooks/useGetCurrentDate';
 const App = () => {
   const { keepingLoginState, getUserInfo } = useUser();
 
+  const nowDate = new Date();
+  const year = nowDate.getFullYear();
+  const month = nowDate.getMonth() + 1;
+
   useEffect(() => {
     // 만약 로그인된 상태면
     auth.onAuthStateChanged(user => {
@@ -30,7 +34,8 @@ const App = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   //현재 날짜 값
-  useGetCurrentDate();
+  useGetCurrentDate({ year, month });
+
   return (
     <>
       <Layout>

--- a/src/components/Common/Modal/ModalComponents/AddReceiptModal/AddReceiptForm.tsx
+++ b/src/components/Common/Modal/ModalComponents/AddReceiptModal/AddReceiptForm.tsx
@@ -13,6 +13,7 @@ import { TReceipt } from 'store/reducers/accoutBook-Slice';
 import { AiFillDelete } from 'react-icons/ai';
 import { useAppSelector } from 'store/store';
 import { shallowEqual } from 'react-redux';
+
 interface AddReceiptFormProps {
   data: Tdata;
   onClose: () => void;
@@ -33,13 +34,17 @@ const AddReceiptForm = ({ data, onClose, update }: AddReceiptFormProps) => {
       receipt => receipt.id === state.accountBook.selectId,
     ),
   );
+  const addReceiptCurrentState = useAppSelector(
+    state => state.modal.receipt.isNew,
+  );
 
   const currentTime = useMemo(() => {
     const time = moment();
-    if (date && month && !update) {
+    if (!update && !addReceiptCurrentState) {
       time.month((month as number) - 1);
       time.date(date as number);
     }
+
     return time;
   }, [date, month, update]);
 
@@ -95,6 +100,7 @@ const AddReceiptForm = ({ data, onClose, update }: AddReceiptFormProps) => {
     } else {
       addReceipt(responseObj);
     }
+
     onClose();
   };
 

--- a/src/components/Common/MonthSelector/MonthSelector.tsx
+++ b/src/components/Common/MonthSelector/MonthSelector.tsx
@@ -26,7 +26,7 @@ const MonthSelector = () => {
   const firstMonth = useAppSelector(state => state.accountBook.firstDate.month);
 
   //현재 날짜 값
-  useGetCurrentDate();
+  useGetCurrentDate({ year, month });
 
   const dates = useMemo(() => {
     const firstDate = new Date(firstYear, firstMonth);

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -5,7 +5,7 @@ import { AiOutlinePlus } from 'react-icons/ai';
 import { ProfileWrap, ProfileInfo, AddListButton } from './Profile.style';
 import AddReceiptModal from '../Common/Modal/ModalComponents/AddReceiptModal';
 import useModal from 'hooks/useModal';
-import { changeModalUpdate } from 'store/reducers/modal-Slice';
+import { changeModalUpdate, changeModalNew } from 'store/reducers/modal-Slice';
 import useAccountBook from 'store/hooks/useAccountBook';
 
 const Profile = () => {
@@ -24,14 +24,15 @@ const Profile = () => {
       .reduce((acc, current) => acc! + current!, 0);
 
   const onClickModal = useCallback(() => {
-    changeSelectDate({
-      year: 0,
-      month: 0,
-      date: 0,
-      hours: 0,
-      minutes: 0,
-    });
+    // changeSelectDate({
+    //   year: 0,
+    //   month: 0,
+    //   date: 0,
+    //   hours: 0,
+    //   minutes: 0,
+    // });
     dispatch(changeModalUpdate({ state: false }));
+    dispatch(changeModalNew({ state: true }));
     showModal();
   }, []);
 

--- a/src/hooks/useGetCurrentDate.tsx
+++ b/src/hooks/useGetCurrentDate.tsx
@@ -1,17 +1,20 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import useAccountBook from 'store/hooks/useAccountBook';
 import { useAppSelector } from 'store/store';
 
-const useGetCurrentDate = () => {
+interface TgetDate {
+  year: number;
+  month: number;
+}
+const useGetCurrentDate = ({ year, month }: TgetDate) => {
   const { changeSelectDate, readReceipts } = useAccountBook();
   const { uid } = useAppSelector(state => state.user);
 
-  useEffect(() => {
-    const nowDate = new Date();
-    const year = nowDate.getFullYear();
-    const month = nowDate.getMonth() + 1;
+  // const nowDate = new Date();
+  // const year = nowDate.getFullYear();
+  // const month = nowDate.getMonth() + 1;
 
-    // 최초 렌더링시 현재 월을 변경
+  useEffect(() => {
     changeSelectDate({ year, month });
     readReceipts({ year, month });
   }, [uid]);

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -3,10 +3,11 @@ import React, { useCallback } from 'react';
 import { changeSelectIdAction } from 'store/reducers/accoutBook-Slice';
 import {
   changeModalMount,
+  changeModalNew,
   changeModalOpen,
   TModalTypes,
 } from 'store/reducers/modal-Slice';
-import { useAppDispatch } from 'store/store';
+import { useAppDispatch, useAppSelector } from 'store/store';
 import { Keyframes } from 'styled-components';
 import { Down100, Up100 } from 'styles/animations';
 import { VoidExpression } from 'typescript';
@@ -28,7 +29,7 @@ const useModal = ({
   onShow,
 }: useModalProps) => {
   const dispatch = useAppDispatch();
-
+  const { receipt } = useAppSelector(state => state.modal);
   const closeModal = useCallback(() => {
     dispatch(changeModalMount({ modal: modalName, state: true }));
 
@@ -36,6 +37,8 @@ const useModal = ({
       dispatch(changeModalOpen({ modal: modalName, state: false }));
       onClose && onClose();
     }, animeTimeMs);
+
+    if (receipt.isNew) dispatch(changeModalNew({ state: false }));
   }, [animeTimeMs, dispatch, modalName, onClose]);
 
   const showModal = useCallback(() => {

--- a/src/store/reducers/modal-Slice.ts
+++ b/src/store/reducers/modal-Slice.ts
@@ -12,6 +12,7 @@ interface TModal2 {
     isOpen: boolean;
     isUnmount: boolean;
     isUpdate: boolean;
+    isNew: boolean;
   };
 }
 
@@ -20,6 +21,7 @@ const initiaModalState: TModal & TModal2 = {
     isOpen: false,
     isUnmount: false,
     isUpdate: false,
+    isNew: false,
   },
   receipts: {
     isOpen: false,
@@ -57,9 +59,19 @@ const modalSlice = createSlice({
     ) {
       state.receipt.isUpdate = action.payload.state;
     },
+    changeModalNew(
+      state: TModal & TModal2,
+      action: PayloadAction<{ state: boolean }>,
+    ) {
+      state.receipt.isNew = action.payload.state;
+    },
   },
 });
 
-export const { changeModalMount, changeModalOpen, changeModalUpdate } =
-  modalSlice.actions;
+export const {
+  changeModalMount,
+  changeModalOpen,
+  changeModalUpdate,
+  changeModalNew,
+} = modalSlice.actions;
 export default modalSlice.reducer;


### PR DESCRIPTION
- 달력페이지 이동시 monthSelector가 초기화되는 문제
- 내역추가 모달 에서 현재날짜로 나오도록 수정